### PR TITLE
Adding attributes from XML to map

### DIFF
--- a/test/xmap_test.exs
+++ b/test/xmap_test.exs
@@ -18,14 +18,41 @@ defmodule XMapTest do
     map = XMap.from_xml(xml, keys: :atoms)
 
     assert map == %{
-      comments: %{
-        comment: [
-          %{author: %{}, body: "Hello world!", footer: %{}},
-          %{},
-          %{}
-        ]
-      }
-    }
+             comments: %{
+               comment: [
+                 %{author: %{}, body: "Hello world!", footer: %{}},
+                 %{},
+                 %{}
+               ]
+             }
+           }
+  end
+
+  test "parses empty nodes as empty maps with attributes" do
+    xml = """
+    <comments>
+      <comment empty=\"true\">
+        <author/>
+        <body>Hello world!</body>
+        <footer></footer>
+      </comment>
+      <comment empty=\"false\"></comment>
+      <comment/>
+    </comments>
+    """
+
+    map = XMap.from_xml(xml, keys: :atoms, disable_attributes: false)
+
+    assert map == %{
+             comments: %{
+               comment: [
+                 %{author: %{}, body: "Hello world!", footer: %{}},
+                 %{},
+                 %{}
+               ],
+               comment_empty: ["true", "false"]
+             }
+           }
   end
 
   test "parses HTML special entities" do
@@ -39,11 +66,11 @@ defmodule XMapTest do
     map = XMap.from_xml(xml, keys: :atoms)
 
     assert map == %{
-      comment: %{
-        author: "Fernando Tapia",
-        body: "\"Hello world!\""
-      }
-    }
+             comment: %{
+               author: "Fernando Tapia",
+               body: "\"Hello world!\""
+             }
+           }
   end
 
   test "parses CDATA" do
@@ -58,10 +85,79 @@ defmodule XMapTest do
     map = XMap.from_xml(xml, keys: :atoms)
 
     assert map == %{
-      post: %{
-        title: "Hello!",
-        body: "Hello world!"
-      }
-    }
+             post: %{
+               title: "Hello!",
+               body: "Hello world!"
+             }
+           }
+  end
+
+  test "parses xml into strings" do
+    xml = """
+      <post url=\"http://www.google.com\">
+        <title>Google</title>
+      </post>
+    """
+
+    map = XMap.from_xml(xml)
+
+    assert map == %{
+             "post" => %{
+               "title" => "Google"
+             }
+           }
+  end
+
+  test "parses attributes" do
+    xml = """
+      <post url=\"http://www.google.com\">
+        <title>Google</title>
+      </post>
+    """
+
+    map = XMap.from_xml(xml, keys: :atoms, disable_attributes: false)
+
+    assert map == %{
+             post: %{
+               title: "Google"
+             },
+             post_url: "http://www.google.com"
+           }
+  end
+
+  test "parses multiple attributes" do
+    xml = """
+      <post url=\"http://www.google.com\">
+        <title url=\"http://www.google.org\">Google</title>
+      </post>
+    """
+
+    map = XMap.from_xml(xml, keys: :atoms, disable_attributes: false)
+
+    assert map == %{
+             post: %{
+               title: "Google",
+               title_url: "http://www.google.org"
+             },
+             post_url: "http://www.google.com"
+           }
+  end
+
+  test "parses empty attribute tag" do
+    xml = """
+      <post url=\"http://www.google.com\">
+        <title url=\"http://www.google.org\"/>
+      </post>
+    """
+
+    map = XMap.from_xml(xml, keys: :atoms, disable_attributes: false)
+
+    assert map == %{
+             post: %{
+               title: %{},
+               title_url: "http://www.google.org"
+             },
+             post_url: "http://www.google.com"
+           }
   end
 end


### PR DESCRIPTION
Running mix format on xmap.ex and xmap_test.exs
Adding :xmlAttribute check to parse_record to add attributes to map
Updates tests for changes to map